### PR TITLE
build: allow compiling for Windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "subprojects/sfml"]
+	path = subprojects/sfml
+	url = https://github.com/SFML/SFML.git

--- a/README.md
+++ b/README.md
@@ -2,11 +2,30 @@
 A Murder Drones fangame, written in C++ using SFML
 
 # Dependencies
-FeedTheBeast relies on [Simple and Fast Multimedia Library](https://www.sfml-dev.org/). Install it, either through your distro's package manager, or by building it from source, before attempting to build FeedTheBeast. Make sure you're installing version 3.0.0 or later, because older versions do not work (some distro package managers have not yet updated to include the latest version, in which case you'll have to build the library yourself).
+FeedTheBeast relies on [Simple and Fast Multimedia Library](https://www.sfml-dev.org/), which is included as a Git submodule.
+After checking out the repository, run `git submodule update --init` to pull SFML's source code.
+
+Finally, make sure you have both Meson and CMake installed and available in your PATH.
+
+On Linux, SFML requires at least the following libraries (might be a few others too):
+- `libvorbis`
+- `libflac`
+
 
 # Compilation/Installation guide
-This project uses `meson`, a build tool that automatically handles compilation and linking. 
+This project uses `meson`, a build tool that automatically handles compilation and linking.
 
 In order to build FeedTheBeast and run it, you must ensure that you have `meson` (and all its dependencies, notably `ninja`) on your system. It is recommended that you do this through your distro's package manager, but it can also be done through `pip`. See [Meson's installation page](https://mesonbuild.com/Getting-meson.html) for more information.
 
-Once you have Meson installed, clone and `cd` into this repository, then run `meson setup builddir` to create a build directory on your system. Once it's there, `cd` into it and run `meson compile` or `ninja` (either one works, `ninja` is faster, but `meson compile` must be used if you are using a different backend. If you don't know what backend you're using, assume you're using `ninja`). After the project is finished building, you'll see the binary in the build directory.  
+Once you have Meson installed, clone and `cd` into this repository, then run `meson setup builddir` to create a build directory on your system. Once it's there, `cd` into it and run `meson compile` or `ninja` (either one works, `ninja` is faster, but `meson compile` must be used if you are using a different backend. If you don't know what backend you're using, assume you're using `ninja`). After the project is finished building, you'll see the binary in the build directory.
+
+SFML needs CMake in order to compile - if you're seeing errors related to CMake, make sure it's installed and up-to-date.
+
+Quick reference:
+- Clone the repository
+- `git submodule update --init` to pull SFML
+- Install CMake and Meson
+- (Optional) Install dependencies (Vorbis and FLAC)
+- `meson setup builddir && cd builddir`
+- `meson compile`
+- `./FeedTheBeast`

--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,17 @@
-project('FeedTheBeast', 'cpp')
-sfmldep = dependency('sfml-all')
-executable('FeedTheBeast', 'main.cpp', dependencies : sfmldep)
+project('FeedTheBeast', 'cpp', default_options : ['cpp_std=c++17'])
+
+cmake = import('cmake')
+sfml_proj = cmake.subproject('sfml')
+sfml_graphics = sfml_proj.dependency('sfml-graphics')
+sfml_window = sfml_proj.dependency('sfml-window')
+sfml_system = sfml_proj.dependency('sfml-system')
+
+if build_machine.system() == 'windows'
+    compiler = meson.get_compiler('cpp')
+    winmm = compiler.find_library('winmm', required: true)
+    ogl = compiler.find_library('opengl32', required: true)
+    sfml_main = sfml_proj.dependency('sfml-main')
+    executable('FeedTheBeast', 'main.cpp', dependencies : [sfml_graphics, sfml_window, sfml_system, sfml_main, winmm, ogl], win_subsystem: 'console')
+else
+    executable('FeedTheBeast', 'main.cpp', dependencies : [sfml_graphics, sfml_window, sfml_system])
+endif


### PR DESCRIPTION
Barebones setup to allow this to compile in Windows.

I went for compiling SFML locally to avoid the entire kerfuffle of making other people download SFML binaries locally, making sure they are the right version for their compiler, and then telling Meson where to find them, which is error-prone at literally every step of the way.

This approach requires including SFML as a Git submodule, so after merging this we'll all have to run `git submodule update --init` so Git can pull the SFML source code.

SFML uses CMake as a build system - thankfully Meson can build CMake projects, but requires CMake to be installed, so that's a new dependency sadly. (I looked into making a Meson wrap for SFML and I understood nothing from their docs so I stopped quickly. If you really prefer being 100% Meson I could research it more but it'll take a while until I figure everything out.)

Besides that you might have some missing libraries on your system, on my end in WSL2 I only was missing `libvorbis` and `libflac` so make sure to grab those as well if you don't have them yet.

Let me know if you have any questions.