### PR TITLE
Allow compilation on systems with no systemwide SFML install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "subprojects/sfml"]
-	path = subprojects/sfml
-	url = https://github.com/SFML/SFML.git
 [submodule "subprojects/SFML"]
 	path = subprojects/SFML
 	url = https://github.com/SFML/SFML.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "subprojects/sfml"]
+	path = subprojects/sfml
+	url = https://github.com/SFML/SFML.git
+[submodule "subprojects/SFML"]
+	path = subprojects/SFML
+	url = https://github.com/SFML/SFML.git

--- a/README.md
+++ b/README.md
@@ -2,11 +2,30 @@
 A Murder Drones fangame, written in C++ using SFML
 
 # Dependencies
-FeedTheBeast relies on [Simple and Fast Multimedia Library](https://www.sfml-dev.org/). Install it, either through your distro's package manager, or by building it from source, before attempting to build FeedTheBeast. Make sure you're installing version 3.0.0 or later, because older versions do not work (some distro package managers have not yet updated to include the latest version, in which case you'll have to build the library yourself).
+FeedTheBeast relies on [Simple and Fast Multimedia Library](https://www.sfml-dev.org/), which is included as a Git submodule.
+After checking out the repository, run `git submodule update --init` to pull SFML's source code.
+
+Finally, make sure you have both Meson and CMake installed and available in your PATH.
+
+On Linux, SFML requires at least the following libraries (might be a few others too):
+- `libvorbis`
+- `libflac`
+
 
 # Compilation/Installation guide
-This project uses `meson`, a build tool that automatically handles compilation and linking. 
+This project uses `meson`, a build tool that automatically handles compilation and linking.
 
 In order to build FeedTheBeast and run it, you must ensure that you have `meson` (and all its dependencies, notably `ninja`) on your system. It is recommended that you do this through your distro's package manager, but it can also be done through `pip`. See [Meson's installation page](https://mesonbuild.com/Getting-meson.html) for more information.
 
-Once you have Meson installed, clone and `cd` into this repository, then run `meson setup builddir` to create a build directory on your system. Once it's there, `cd` into it and run `meson compile` or `ninja` (either one works, `ninja` is faster, but `meson compile` must be used if you are using a different backend. If you don't know what backend you're using, assume you're using `ninja`). After the project is finished building, you'll see the binary in the build directory.  
+Once you have Meson installed, clone and `cd` into this repository, then run `meson setup builddir` to create a build directory on your system. Once it's there, `cd` into it and run `meson compile` or `ninja` (either one works, `ninja` is faster, but `meson compile` must be used if you are using a different backend. If you don't know what backend you're using, assume you're using `ninja`). After the project is finished building, you'll see the binary in the build directory.
+
+SFML needs CMake in order to compile - if you're seeing errors related to CMake, make sure it's installed and up-to-date.
+
+Quick reference:
+- Clone the repository
+- `git submodule update --init` to pull SFML
+- Install CMake and Meson
+- (Optional) Install dependencies (Vorbis and FLAC)
+- `meson setup builddir && cd builddir`
+- `meson compile`
+- `./FeedTheBeast`

--- a/meson.build
+++ b/meson.build
@@ -1,3 +1,23 @@
 project('FeedTheBeast', 'cpp')
-sfmldep = dependency('sfml-all')
-executable('FeedTheBeast', 'main.cpp', dependencies : sfmldep)
+useSystemSFML = get_option('useSystemSFML')
+
+if useSystemSFML
+  sfmldep = dependency('sfml-all')
+  executable('FeedTheBeast', 'main.cpp', dependencies : sfmldep)
+else
+  cmake = import('cmake')
+  sfml_proj = cmake.subproject('sfml')
+  sfml_graphics = sfml_proj.dependency('sfml-graphics')
+  sfml_window = sfml_proj.dependency('sfml-window')
+  sfml_system = sfml_proj.dependency('sfml-system')
+  
+  if build_machine.system() == 'windows'
+    compiler = meson.get_compiler('cpp')
+    winmm = compiler.find_library('winmm', required: true)
+    ogl = compiler.find_library('opengl32', required: true)
+    sfml_main = sfml_proj.dependency('sfml-main')
+    executable('FeedTheBeast', 'main.cpp', dependencies : [sfml_graphics, sfml_window, sfml_system, sfml_main, winmm, ogl], win_subsystem: 'console')
+  else
+    executable('FeedTheBeast', 'main.cpp', dependencies : [sfml_graphics, sfml_window, sfml_system])
+  endif
+endif

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ if useSystemSFML
   executable('FeedTheBeast', 'main.cpp', dependencies : sfmldep)
 else
   cmake = import('cmake')
-  sfml_proj = cmake.subproject('sfml')
+  sfml_proj = cmake.subproject('SFML')
   sfml_graphics = sfml_proj.dependency('sfml-graphics')
   sfml_window = sfml_proj.dependency('sfml-window')
   sfml_system = sfml_proj.dependency('sfml-system')

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,1 @@
+option('useSystemSFML', type : 'boolean', value : false)


### PR DESCRIPTION
After a lot of bumbling around, and through a lot of checking back on Arqa's pull request, I've finally done this. This uses a subproject to ensure that, even if you don't have SFML installed systemwide on your machine, you can still compile the program. Additionally, through use of a meson option, you can still choose to use your systemwide SFML install for faster compile times (much, *much* faster compile times).

This does require that cmake be installed on the user's system in addition to meson, and, on Linux specifically, it might require some other dependencies too? Specifically because for SFML to be compiled, you still obviously need the SFML dependencies. According to their website, you need:
- libxrandr-dev
- libxcursor-dev
- libudev-dev
- libflac-dev
- libvorbis-dev
- libgl1-mesa-dev
- libegl1-mesa-dev
- libdrm-dev
- libgbm-dev
And I imagine that the non-dev versions of all of these work too. Probably. Since this only applies to Linux, just use your distro's package manager to install all of these. I guess on Windows they use libraries that come with the OS instead. Idk lol I don't use Windows. 

I haven't yet updated the README, but I will also change it (and in particular the compilation instructions) to reflect the way that this works now. 